### PR TITLE
Show name of specific branches/tags when using %b option

### DIFF
--- a/bin/vcprompt
+++ b/bin/vcprompt
@@ -608,7 +608,7 @@ def svn(options):
 
     if returncode == 0:
         # compile some regexes
-        branch_regex = re.compile('((tags|branches)|trunk)')
+        branch_regex = re.compile('((tags|branches)/([^/]*)|trunk)')
         revision_regex = re.compile('^Revision: (?P<revision>\d+)')
 
         for line in output.split('\n'):


### PR DESCRIPTION
Hi,

Thanks for vcprompt! Really helps having a python version, so I can easily just sync it to all of our servers and use it in remote shells as well without having to rebuild.

See pull request, I've changed the output of %b option for svn a little bit. When using for example %s:%b  instead of showing just: 

svn:branches

it will now show

svn:branches/[name of branch]

Which for me makes more sense.

Cheers,
Remco
