### PR TITLE
Support showing the revision, not just tags

### DIFF
--- a/bin/vcprompt
+++ b/bin/vcprompt
@@ -470,7 +470,7 @@ def git(options):
                     branch = (line.split('/')[-1] or options.unknown)
                     break
             if branch == options.unknown:
-                command = 'git describe --tags'
+                command = 'git describe --always'
                 process = Popen(command.split(), stdout=PIPE, stderr=PIPE)
                 output = process.communicate()[0]
                 returncode = process.returncode


### PR DESCRIPTION
When checking out git revisions that aren't tags or branches it's nice to see the sha1.
