### PR TITLE
modify git to allow vcprompt to function in git subrepositories

### DIFF
--- a/bin/vcprompt
+++ b/bin/vcprompt
@@ -442,6 +442,9 @@ def git(options):
     """
     staged = branch = sha = modified = untracked = options.unknown
 
+    if os.path.isfile(options.file):
+        options.file = open(options.file, "r").read().rstrip('\n').split(" ")[1]
+
     def revstring(ref, chars=7):
         if not os.path.exists(ref):
             return ''


### PR DESCRIPTION
in a git subrepo, there is no .git directory. instead there is a file called .git which has text in it that points to the subrepo's git directory that lives inside the .git directory of the parent repo. this modification tests whether the .git in a repo is a file and if so, parses the contents of the file to find the git repo and sets function.file to that correct directory.
