### PR TITLE
A little enhancement in "svn info" parsing for branches/tags/trunk

### DIFF
--- a/bin/vcprompt
+++ b/bin/vcprompt
@@ -621,7 +621,7 @@ def svn(options):
         for line in output.split('\n'):
             # branch
             if '%b' in options.format:
-                if re.match('URL:', line):
+                if re.match('URL', line):
                     matches = re.search(branch_regex, line)
                     if matches:
                         branch = matches.groups(0)[0]


### PR DESCRIPTION
For svn vcs, sometimes 'URL:" does not match any line of the splitted svn info output.
--> Which gives "unknown" when asking for branch in format string.

This can be be due to a trailing space before ':' character or whatever. 
Using "URL" only in re.match(...) seems to solve the issue.
