### PR TITLE
Add %P and %p path specs for all VCS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -106,6 +106,14 @@ of all the available tokens:
   Displays an exclamtion mark (`!`) if there is any untracked files in
   the repository.
 
+* `%P`
+
+  The name of the repository root directory (typically a project name).
+
+* `%p`
+
+  The relative path from the repository root directory to the current
+  directory (or the directory specified by `--path`).
 
 
 REQUIREMENTS

--- a/bin/vcprompt
+++ b/bin/vcprompt
@@ -124,6 +124,7 @@ def vcprompt(options):
 
     """
     options.path = os.path.abspath(os.path.expanduser(options.path))
+    original_path = options.path
     prompt = None
     count = 0
 
@@ -152,6 +153,9 @@ def vcprompt(options):
 
             prompt = vcs(options)
             if prompt is not None:
+                prompt = prompt.replace("%P", os.path.basename(options.path))
+                prompt = prompt.replace("%p", os.path.relpath(original_path,
+                                                              options.path))
                 return prompt
 
         if options.depth:


### PR DESCRIPTION
Make it possible to do e.g. `$(vcprompt -f "(%P) %s:%b%m%a%u %p")` to get a prompt like:

`(nose) svn:trunk examples/plugin`

Make that `$(vcprompt -f "(%P) %s:%b%m%a%u %p" || pwd)` to get the current path if not inside a VCS working directory.
