### PR TITLE
fix to return git sha after running garbage collection

### DIFF
--- a/bin/vcprompt
+++ b/bin/vcprompt
@@ -465,8 +465,18 @@ def git(options):
 
     def revstring(ref, chars=7):
         if not os.path.exists(ref):
-            return ''
-
+            # look for packed-refs file in case garbage collection just run
+            try:
+                pr = os.path.join(options.file, 'packed-refs')
+                ref = ref.split('/', 1)[1]
+                fh = open(pr, 'r')
+                for line in fh:
+                    line = line.strip()
+                    if line.endswith(ref):
+                        return line.split(" ")[0][0:chars]
+                return ''
+            except IOError:
+                return ''
         try:
             fh = open(ref, 'r')
             for line in fh:


### PR DESCRIPTION
if you run `git gc` in a git repo, the garbage collection process removes all the `refs/heads/` files and replaces them with a file called packed-refs in .git. in this case, vcprompt does not return a sha string for the current branch.

this patch modifies the revstring function so that if `refs/heads/<branch>` does not exist, instead of immediately returning '', revstring looks for packed-refs, parses it for the correct sha and returns it.
