### PR TITLE
fix typo in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,7 +17,7 @@ Download vcprompt, make it executable and add it to your prompt:
 
 For bash, you'll want to do something like this:
 
-    $ export PS1='\u@\h:\w \$(vcprompt)\$'
+    $ export PS1='\u@\h:\w $(vcprompt)\$'
 
 ZSH users should be aware that they will have to set the
 `PROMPT_SUBST` option first:


### PR DESCRIPTION
Mini-fix in README: The backslash before the $, \$, cause the $(vcprompt) to not be evaluated properly.
